### PR TITLE
chore(auth, generator, inject, logger, session): add homepage links t…

### DIFF
--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -14,6 +14,7 @@
     "type": "git",
     "url": "https://github.com/MrBacony/analog-tools.git"
   },
+  "homepage": "https://github.com/MrBacony/analog-tools/tree/main/packages/auth#readme",
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -8,6 +8,7 @@
     "type": "git",
     "url": "https://github.com/MrBacony/analog-tools.git"
   },
+  "homepage": "https://github.com/MrBacony/analog-tools/tree/main/packages/generator#readme",
   "main": "./src/index.js",
   "types": "./src/index.d.ts",
   "license": "MIT",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/MrBacony/analog-tools.git"
   },
+  "homepage": "https://github.com/MrBacony/analog-tools/tree/main/packages/inject#readme",
   "keywords": [
     "analogjs",
     "di",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/MrBacony/analog-tools.git"
   },
+  "homepage": "https://github.com/MrBacony/analog-tools/tree/main/packages/logger#readme",
   "keywords": [
     "analogjs",
     "logger",

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -9,6 +9,7 @@
     "type": "git",
     "url": "https://github.com/MrBacony/analog-tools.git"
   },
+  "homepage": "https://github.com/MrBacony/analog-tools/tree/main/packages/session#readme",
   "keywords": [
     "analogjs",
     "session",


### PR DESCRIPTION
…o package.json files
This pull request adds a `homepage` field to the `package.json` files for several packages. This field provides a direct link to each package's documentation or readme on GitHub, improving discoverability and documentation access.

Documentation and metadata improvements:

* Added a `homepage` field with a link to the package's GitHub readme in the following `package.json` files:
  * `packages/auth/package.json`
  * `packages/generator/package.json`
  * `packages/inject/package.json`
  * `packages/logger/package.json`
  * `packages/session/package.json`