### PR TITLE
64 fixauth redirect loop with h3 usebase path stripping

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "analog-tools",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Tools and utilities for AnalogJS applications",
   "license": "MIT",
   "scripts": {},

--- a/packages/auth-angular/package.json
+++ b/packages/auth-angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/auth-angular",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "peerDependencies": {
     "@analogjs/router": "^2.5.0",
     "@angular/common": "^19.0.0 || ^20.0.0 || ^21.0.0",

--- a/packages/auth/package.json
+++ b/packages/auth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/auth",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Authentication module for AnalogJS applications",
   "type": "module",
   "main": "./index.cjs",
@@ -31,9 +31,9 @@
     "analog-tools"
   ],
   "dependencies": {
-    "@analog-tools/session": "^0.0.19",
-    "@analog-tools/inject": "^0.0.19",
-    "@analog-tools/logger": "^0.0.19"
+    "@analog-tools/session": "^0.0.20",
+    "@analog-tools/inject": "^0.0.20",
+    "@analog-tools/logger": "^0.0.20"
   },
   "peerDependencies": {
     "h3": "^1.15.2",

--- a/packages/auth/src/server/functions/handleAuthRoute.spec.ts
+++ b/packages/auth/src/server/functions/handleAuthRoute.spec.ts
@@ -111,4 +111,14 @@ describe('handleAuthRoute', () => {
     expect(mockAuthService.initSession).toHaveBeenCalledWith(mockEvent);
     expect(result).toBe('callback-handler-result');
   });
+
+  it('should handle h3 useBase stripped auth alias routes', async () => {
+    mockEvent = { path: '/auth/login' } as Partial<H3Event>;
+
+    const result = await handleAuthRoute(mockEvent as H3Event);
+
+    expect(mockAuthService.initSession).toHaveBeenCalledWith(mockEvent);
+    expect(getLastPathSegment).toHaveBeenCalledWith('/api/auth/login');
+    expect(result).toBe('login-handler-result');
+  });
 });

--- a/packages/auth/src/server/functions/handleAuthRoute.ts
+++ b/packages/auth/src/server/functions/handleAuthRoute.ts
@@ -3,10 +3,13 @@ import { registerRoutes } from './registerRoutes';
 import { OAuthAuthenticationService } from '../services/oauth-authentication.service';
 import { getLastPathSegment } from '../utils/getLastPathSegment';
 import { inject } from '@analog-tools/inject';
+import { isAuthRoutePath, normalizeAuthPath } from '../utils/auth-route-path';
 
 export async function handleAuthRoute(event: H3Event) {
-  if (event.path.includes('/api/auth/')) {
-    const path = getLastPathSegment(event.path);
+  const normalizedPath = normalizeAuthPath(event.path);
+
+  if (isAuthRoutePath(normalizedPath)) {
+    const path = getLastPathSegment(normalizedPath);
 
     if (!path) {
       throw createError({

--- a/packages/auth/src/server/functions/useAnalogAuthMiddleware.spec.ts
+++ b/packages/auth/src/server/functions/useAnalogAuthMiddleware.spec.ts
@@ -130,6 +130,16 @@ describe('useAnalogAuthMiddleware', () => {
     expect(mockCheckAuthentication).not.toHaveBeenCalled();
   });
 
+  it('should bypass authentication for h3 useBase stripped auth routes', async () => {
+    mockGetRequestURL.mockReturnValue({ pathname: '/auth/login' });
+
+    await useAnalogAuthMiddleware(mockEvent);
+
+    expect(mockAuthService.initSession).not.toHaveBeenCalled();
+    expect(mockCheckAuthentication).not.toHaveBeenCalled();
+    expect(sendRedirect).not.toHaveBeenCalledWith(mockEvent, '/api/auth/login');
+  });
+
   it('should bypass authentication for authenticated routes', async () => {
     mockGetRequestURL.mockReturnValue({ pathname: '/api/auth/authenticated' });
 

--- a/packages/auth/src/server/functions/useAnalogAuthMiddleware.ts
+++ b/packages/auth/src/server/functions/useAnalogAuthMiddleware.ts
@@ -6,6 +6,7 @@ import { TRPCError } from '@trpc/server';
 import { checkAuthentication } from './checkAuthentication';
 import { updateSession } from '@analog-tools/session';
 import { sanitizeRedirectUrl } from '../utils/sanitizeRedirectUrl';
+import { isAuthRoutePath } from '../utils/auth-route-path';
 
 export async function useAnalogAuthMiddleware(event: H3Event) {
   // Skip authentication for public auth routes
@@ -17,8 +18,9 @@ export async function useAnalogAuthMiddleware(event: H3Event) {
   logger.info('Processing authentication middleware', pathname);
 
   // Public routes that should bypass authentication
-  // All /api/auth/* routes are handled by handleAuthRoute
-  if (pathname.startsWith('/api/auth/')) {
+  // All internal auth routes are handled by handleAuthRoute.
+  // Nitro/h3 may strip the /api mount prefix before we see the pathname.
+  if (isAuthRoutePath(pathname)) {
     return;
   }
 

--- a/packages/auth/src/server/utils/auth-route-path.spec.ts
+++ b/packages/auth/src/server/utils/auth-route-path.spec.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { isAuthRoutePath, normalizeAuthPath } from './auth-route-path';
+
+describe('isAuthRoutePath', () => {
+  it('recognizes /api/auth/login', () => {
+    expect(isAuthRoutePath('/api/auth/login')).toBe(true);
+  });
+
+  it('recognizes /auth/login (h3-stripped alias)', () => {
+    expect(isAuthRoutePath('/auth/login')).toBe(true);
+  });
+
+  it('rejects /api/users', () => {
+    expect(isAuthRoutePath('/api/users')).toBe(false);
+  });
+
+  it('rejects /login', () => {
+    expect(isAuthRoutePath('/login')).toBe(false);
+  });
+});
+
+describe('normalizeAuthPath', () => {
+  it('maps /auth/login → /api/auth/login', () => {
+    expect(normalizeAuthPath('/auth/login')).toBe('/api/auth/login');
+  });
+
+  it('leaves /api/auth/callback unchanged', () => {
+    expect(normalizeAuthPath('/api/auth/callback')).toBe('/api/auth/callback');
+  });
+
+  it('leaves /api/users unchanged', () => {
+    expect(normalizeAuthPath('/api/users')).toBe('/api/users');
+  });
+});

--- a/packages/auth/src/server/utils/auth-route-path.ts
+++ b/packages/auth/src/server/utils/auth-route-path.ts
@@ -1,0 +1,14 @@
+/** Returns true if path refers to an auth route, regardless of /api prefix */
+export function isAuthRoutePath(path: string): boolean {
+  const normalized = path.startsWith('/api') ? path : `/api${path}`;
+  return normalized.startsWith('/api/auth/') || normalized === '/api/auth';
+}
+
+/** Normalizes /auth/* → /api/auth/* for internal dispatch */
+export function normalizeAuthPath(path: string): string {
+  if (path.startsWith('/auth/') || path === '/auth') {
+    return `/api${path}`;
+  }
+
+  return path;
+}

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/generator",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Code generation tools for AnalogJS applications",
   "type": "commonjs",
   "author": "Gregor Speck <gregor.speck@gmail.com>",

--- a/packages/inject/package.json
+++ b/packages/inject/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/inject",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Dependency injection for AnalogJS server-side applications",
   "main": "./index.cjs",
   "module": "./index.js",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/logger",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Logging utility for AnalogJS applications",
   "main": "./index.cjs",
   "module": "./index.js",
@@ -25,7 +25,7 @@
     "h3": "^1.10.1"
   },
   "peerDependencies": {
-    "@analog-tools/inject": "^0.0.19"
+    "@analog-tools/inject": "^0.0.20"
   },
   "devDependencies": {},
   "publishConfig": {

--- a/packages/session/package.json
+++ b/packages/session/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@analog-tools/session",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "description": "Session management for AnalogJS server-side applications",
   "main": "./index.cjs",
   "module": "./index.js",
@@ -29,7 +29,7 @@
     "defu": "^6.1.4",
     "uncrypto": "^0.1.3",
     "unstorage": "^1.16.0",
-    "@analog-tools/inject": "^0.0.19"
+    "@analog-tools/inject": "^0.0.20"
   },
   "peerDependencies": {
     "h3": "^1.15.2"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes — Version 0.0.20

* **Bug Fixes**
  * Improved authentication route detection to handle alternative route path formats when mount prefixes are stripped.

* **Chores**
  * Package versions updated to 0.0.20 across all modules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MrBacony/analog-tools/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->