### PR TITLE
build(ci): repair the publish workflow and finish the Node 24 action bumps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
-        with:
-          version: 10
 
       - uses: actions/setup-node@v7
         with:
@@ -98,11 +96,10 @@ jobs:
           git push origin "v${{ steps.version.outputs.version }}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v3
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           tag_name: v${{ steps.version.outputs.version }}
-          release_name: Release v${{ steps.version.outputs.version }}
+          name: Release v${{ steps.version.outputs.version }}
           draft: false
           prerelease: false

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -60,7 +60,7 @@ jobs:
         run: node tools/scripts/update-package-versions.js ${{ steps.new.outputs.version }}
       
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: "chore: bump version to ${{ steps.new.outputs.version }}"
           title: "chore: release v${{ steps.new.outputs.version }}"


### PR DESCRIPTION
## Why

Merging #70 triggered the first real run of the pnpm-based `publish.yml`. It failed — but not where expected. It never reached the npm publish step:

```
Error: Multiple versions of pnpm specified:
  - version 10 in the GitHub Action config with the key "version"
  - version pnpm@10.0.0 in the package.json with the key "packageManager"
Remove one of these versions to avoid version mismatch errors like ERR_PNPM_BAD_PM_VERSION
```

`pnpm/action-setup` refuses to run when the version is specified in both places. `ci.yml` omits `version:` and has been passing all along; `publish.yml` did not. This check exists in v4 as well, so it came from the original pnpm migration rather than the recent action bump — it simply never surfaced, because `publish.yml` only triggers on push to `main` touching `package.json`.

This blocks any release, so it has to land before the next version bump.

## What changed

**`publish.yml`**
- Dropped `version: 10` from the pnpm setup step; the version now comes from `packageManager` in `package.json`, matching `ci.yml`.
- `softprops/action-gh-release` v1 → v3. v1 targets the **node16** runtime, which is well past deprecation.
- Fixed a latent bug found while bumping: the step passed `release_name:`, which this action has never had as an input. The correct name is `name:`, so the release title was being silently ignored. The v1-era `env: GITHUB_TOKEN` is replaced by the `token:` input.

**`version-bump.yml`**
- `peter-evans/create-pull-request` v6 (node20) → v8 (node24). All inputs used here — `commit-message`, `title`, `body`, `branch`, `delete-branch`, `labels` — still exist unchanged in v8.

## Verification

Both target versions were checked against their upstream `action.yml` before bumping: `softprops/action-gh-release@v3.0.2` and `peter-evans/create-pull-request@v8.1.1` both declare `using: node24`, and the input lists were diffed against what these workflows actually pass.

**Caveat:** CI on this PR does *not* exercise either workflow. `publish.yml` only runs on push to `main`, and `version-bump.yml` only on `workflow_dispatch`. The publish fix can only be confirmed by the next release run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated publishing workflow to use the latest release action configuration.
  * Improved release metadata handling during automated publishing.
  * Updated the automated version-bump workflow’s pull request action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->