### PR TITLE
fix(release): stop the version bump from clobbering workspace: ranges

### DIFF
--- a/tools/scripts/update-package-versions.js
+++ b/tools/scripts/update-package-versions.js
@@ -78,10 +78,18 @@ function updateVersions(targetVersion) {
     ['dependencies', 'peerDependencies'].forEach((depType) => {
       if (pkg[depType]) {
         Object.keys(pkg[depType]).forEach((dep) => {
-          if (packageNames.includes(dep)) {
-            pkg[depType][dep] = `^${targetVersion}`;
-            updated = true;
-          }
+          if (!packageNames.includes(dep)) return;
+
+          // `workspace:` ranges must survive the bump. pnpm needs them to link
+          // the local packages, and rewriting them here would both break
+          // `pnpm install --frozen-lockfile` (the lockfile still records the
+          // workspace specifier) and point the source tree at versions that
+          // are not on npm yet. packages/auth/tools/update-package-json.js
+          // resolves them to concrete versions when building for publish.
+          if (String(pkg[depType][dep]).startsWith('workspace:')) return;
+
+          pkg[depType][dep] = `^${targetVersion}`;
+          updated = true;
         });
       }
     });


### PR DESCRIPTION
## Why

Triggering the Version Bump workflow (run `30201606884`) produced #72 — and that PR is not releasable.

`tools/scripts/update-package-versions.js` rewrites every internal dependency to `^<version>`. Since the pnpm migration those dependencies are `workspace:*` ranges, so the bump clobbered them:

```diff
-    "@analog-tools/session": "workspace:*",
-    "@analog-tools/inject": "workspace:*",
-    "@analog-tools/logger": "workspace:*"
+    "@analog-tools/session": "^0.0.21",
+    "@analog-tools/inject": "^0.0.21",
+    "@analog-tools/logger": "^0.0.21"
```

The lockfile still records `workspace:*` as the specifier, so the branch fails the install that both `ci.yml` and `publish.yml` run:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/auth/package.json
```

Merging #72 would have pushed an uninstallable tree to `main` and released nothing — `publish.yml` dies at "Install dependencies", well before it reaches npm. The rewrite additionally pointed the source tree at `^0.0.21`, a version that does not exist on npm yet.

## What changed

The bump now leaves `workspace:` ranges alone. They are required for pnpm to link the local packages, and `packages/auth/tools/update-package-json.js` already resolves them to concrete versions when building for publish, so nothing is lost on the published manifests. Internal dependencies pinned by a plain version string are still rewritten as before.

## Verification

Ran the fixed script against a clean tree with `0.0.21`:

- It now touches only the `version` field — one changed line per manifest, versus four in `packages/auth` before.
- All four `workspace:*` ranges survive (`packages/auth` ×3, `packages/logger` ×1).
- `pnpm install --frozen-lockfile` succeeds on the bumped tree, where the same command fails on #72's branch.

The test bumps were reverted; this PR contains the script fix only.

## Follow-up

#72 should be closed and the bump re-run once this lands. Note also that #72 got no CI at all — its check sat at `action_required`, because PRs opened by `GITHUB_TOKEN` do not trigger workflows. Any bump PR will need its checks approved manually before merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package version updates now preserve dependencies that use workspace-based version ranges.
  * Other managed dependency versions continue to update as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->